### PR TITLE
Experimental last interval sma

### DIFF
--- a/metricq_grafana/utils.py
+++ b/metricq_grafana/utils.py
@@ -139,9 +139,9 @@ class Target:
                 ma_integral = 0
                 ma_active_time = 0
                 ma_begin_index = 0
-                ma_begin_time = response_aggregates[0].time
+                ma_begin_time = response_aggregates[0].timestamp
                 ma_end_index = 0
-                ma_end_time = response_aggregates[0].time
+                ma_end_time = response_aggregates[0].timestamp
 
                 # we assume LAST semantic, but this should not matter for equidistant intervals
                 interval_durations = [0] + [

--- a/metricq_grafana/utils.py
+++ b/metricq_grafana/utils.py
@@ -179,7 +179,7 @@ class Target:
                         step_duration = next_step_time - ma_begin_time
                         # scale can be 0 (everything is nop),
                         # 1 (full interval needs to be removed), or something in between
-                        scale = step_duration / interval_durations[ma_begin_index]
+                        scale = step_duration.ns / interval_durations[ma_begin_index].ns
                         ma_active_time -= (
                             timeaggregate[ma_begin_index].active_time * scale
                         )
@@ -207,7 +207,7 @@ class Target:
                         step_duration = next_step_time - ma_end_time
                         # scale can be 0 (everything is nop),
                         # 1 (full interval needs to be removed), or something in between
-                        scale = step_duration / interval_durations[ma_end_index]
+                        scale = step_duration.ns / interval_durations[ma_end_index].ns
                         ma_active_time += (
                             timeaggregate[ma_end_index].active_time * scale
                         )

--- a/metricq_grafana/utils.py
+++ b/metricq_grafana/utils.py
@@ -138,9 +138,9 @@ class Target:
             if target_type == "sma":
                 ma_integral = 0
                 ma_active_time = 0
-                ma_begin_index = 0
+                ma_begin_index = 1
                 ma_begin_time = response_aggregates[0].timestamp
-                ma_end_index = 0
+                ma_end_index = 1
                 ma_end_time = response_aggregates[0].timestamp
 
                 # we assume LAST semantic, but this should not matter for equidistant intervals

--- a/metricq_grafana/utils.py
+++ b/metricq_grafana/utils.py
@@ -144,7 +144,7 @@ class Target:
                 ma_end_time = response_aggregates[0].timestamp
 
                 # we assume LAST semantic, but this should not matter for equidistant intervals
-                interval_durations = [0] + [
+                interval_durations = [Timedelta(0)] + [
                     current_ta.timestamp - previous_ta.timestamp
                     for previous_ta, current_ta in zip(
                         response_aggregates, response_aggregates[1:]
@@ -156,7 +156,7 @@ class Target:
                 ):
                     # The moving average window is symmetric around the current *interval* - not the current point
                     # How much time is covered by the current interval width and how much is on both sides "outside"
-                    assert current_interval_duration >= 0
+                    assert current_interval_duration >= Timedelta(0)
                     outside_time = (
                         self.moving_average_interval - current_interval_duration
                     )

--- a/metricq_grafana/utils.py
+++ b/metricq_grafana/utils.py
@@ -144,12 +144,15 @@ class Target:
                 ma_end_time = response_aggregates[0].timestamp
 
                 # we assume LAST semantic, but this should not matter for equidistant intervals
-                interval_durations = [Timedelta(0)] + [
+                interval_durations = [
                     current_ta.timestamp - previous_ta.timestamp
                     for previous_ta, current_ta in zip(
                         response_aggregates, response_aggregates[1:]
                     )
                 ]
+                # We can't handle this now...
+                assert min(interval_durations) > Timedelta(0)
+                interval_durations = [Timedelta(0)] + interval_durations
 
                 for timeaggregate, current_interval_duration in zip(
                     response_aggregates, interval_durations
@@ -181,9 +184,11 @@ class Target:
                         # 1 (full interval needs to be removed), or something in between
                         scale = step_duration.ns / interval_durations[ma_begin_index].ns
                         ma_active_time -= (
-                            timeaggregate[ma_begin_index].active_time * scale
+                            response_aggregates[ma_begin_index].active_time * scale
                         )
-                        ma_integral -= timeaggregate[ma_begin_index].integral * scale
+                        ma_integral -= (
+                            response_aggregates[ma_begin_index].integral * scale
+                        )
 
                         ma_begin_time = next_step_time
                         assert (
@@ -209,9 +214,11 @@ class Target:
                         # 1 (full interval needs to be removed), or something in between
                         scale = step_duration.ns / interval_durations[ma_end_index].ns
                         ma_active_time += (
-                            timeaggregate[ma_end_index].active_time * scale
+                            response_aggregates[ma_end_index].active_time * scale
                         )
-                        ma_integral += timeaggregate[ma_end_index].integral * scale
+                        ma_integral += (
+                            response_aggregates[ma_end_index].integral * scale
+                        )
 
                         ma_end_time = next_step_time
                         assert (

--- a/metricq_grafana/utils.py
+++ b/metricq_grafana/utils.py
@@ -157,17 +157,17 @@ class Target:
                     # The moving average window is symmetric around the current *interval* - not the current point
                     # How much time is covered by the current interval width and how much is on both sides "outside"
                     assert current_interval_duration >= Timedelta(0)
-                    outside_time = (
+                    outside_duration = (
                         self.moving_average_interval - current_interval_duration
                     )
                     # If the current interval is wider than the target moving average window, just use the current one
-                    outside_time = max(0, outside_time)
+                    outside_duration = max(Timedelta(0), outside_duration)
                     seek_begin_time = (
                         timeaggregate.timestamp
                         - current_interval_duration
-                        - outside_time / 2
+                        - outside_duration / 2
                     )
-                    seek_end_time = timeaggregate.timestamp + outside_time / 2
+                    seek_end_time = timeaggregate.timestamp + outside_duration / 2
 
                     # TODO unify this code
                     # Move left part of the window

--- a/metricq_grafana/utils.py
+++ b/metricq_grafana/utils.py
@@ -233,7 +233,9 @@ class Target:
                         continue
                     if ma_active_time == 0:
                         continue
+
                     value = ma_integral / ma_active_time
+                    timestamp = timeaggregate.timestamp
 
                     if not self.order_time_value:
                         dp.append((sanitize_number(value), timestamp.posix_ms))

--- a/metricq_grafana/utils.py
+++ b/metricq_grafana/utils.py
@@ -150,7 +150,7 @@ class Target:
                         response_aggregates, response_aggregates[1:]
                     )
                 ]
-                # We can't handle this now...
+                # We need strong monotony. DB-HTA guarantees it currently
                 assert min(interval_durations) > Timedelta(0)
                 interval_durations = [Timedelta(0)] + interval_durations
 
@@ -172,7 +172,7 @@ class Target:
                     )
                     seek_end_time = timeaggregate.timestamp + outside_duration / 2
 
-                    # TODO unify this code
+                    # TODO unify these two loops
                     # Move left part of the window
                     while ma_begin_time < seek_begin_time:
                         next_step_time = min(

--- a/metricq_grafana/utils.py
+++ b/metricq_grafana/utils.py
@@ -163,17 +163,18 @@ class Target:
                     # If the current interval is wider than the target moving average window, just use the current one
                     outside_time = max(0, outside_time)
                     seek_begin_time = (
-                        timeaggregate.time
+                        timeaggregate.timestamp
                         - current_interval_duration
                         - outside_time / 2
                     )
-                    seek_end_time = timeaggregate.time + outside_time / 2
+                    seek_end_time = timeaggregate.timestamp + outside_time / 2
 
                     # TODO unify this code
                     # Move left part of the window
                     while ma_begin_time < seek_begin_time:
                         next_step_time = min(
-                            response_aggregates[ma_begin_index].time, seek_begin_time
+                            response_aggregates[ma_begin_index].timestamp,
+                            seek_begin_time,
                         )
                         step_duration = next_step_time - ma_begin_time
                         # scale can be 0 (everything is nop),
@@ -185,8 +186,14 @@ class Target:
                         ma_integral -= timeaggregate[ma_begin_index].integral * scale
 
                         ma_begin_time = next_step_time
-                        assert ma_begin_time <= response_aggregates[ma_begin_index].time
-                        if ma_begin_time == response_aggregates[ma_begin_index].time:
+                        assert (
+                            ma_begin_time
+                            <= response_aggregates[ma_begin_index].timestamp
+                        )
+                        if (
+                            ma_begin_time
+                            == response_aggregates[ma_begin_index].timestamp
+                        ):
                             # Need to move to the next interval
                             ma_begin_index += 1
 
@@ -195,7 +202,7 @@ class Target:
                         response_aggregates
                     ):
                         next_step_time = min(
-                            response_aggregates[ma_end_index].time, seek_end_time
+                            response_aggregates[ma_end_index].timestamp, seek_end_time
                         )
                         step_duration = next_step_time - ma_end_time
                         # scale can be 0 (everything is nop),
@@ -207,8 +214,10 @@ class Target:
                         ma_integral += timeaggregate[ma_end_index].integral * scale
 
                         ma_end_time = next_step_time
-                        assert ma_end_time <= response_aggregates[ma_end_index].time
-                        if ma_end_time == response_aggregates[ma_end_index].time:
+                        assert (
+                            ma_end_time <= response_aggregates[ma_end_index].timestamp
+                        )
+                        if ma_end_time == response_aggregates[ma_end_index].timestamp:
                             # Need to move to the next interval
                             ma_end_index += 1
 


### PR DESCRIPTION
It turns out that SMA is actually horribly complicated for time intervals / LAST semantic.
This solution preserves the timestamps of each measurement point and uses partial intervals arranges symmetrically around the current *interval*.

The implementation seems to work somewhat better than the current master implementation for corner cases