### PR TITLE
feat: add analyze endpoint

### DIFF
--- a/metricq_grafana/routes.py
+++ b/metricq_grafana/routes.py
@@ -6,6 +6,7 @@ from .views import (
     search,
     metadata,
     test_connection,
+    analyze,
 )
 
 
@@ -13,6 +14,9 @@ def setup_routes(app, cors):
     """Setup routes and cors for app."""
     resource = cors.add(app.router.add_resource("/query"))
     cors.add(resource.add_route("POST", query))
+
+    resource = cors.add(app.router.add_resource("/analyze"))
+    cors.add(resource.add_route("POST", analyze))
 
     resource = cors.add(app.router.add_resource("/search"))
     cors.add(resource.add_route("POST", search))

--- a/metricq_grafana/routes.py
+++ b/metricq_grafana/routes.py
@@ -1,22 +1,32 @@
 """Module for route setup"""
+import functools
+
+from .amqp import get_analyze_data, get_history_data
 from .views import (
     legacy_cntr_status,
     legacy_counter_data,
-    query,
     search,
     metadata,
     test_connection,
-    analyze,
+    view_with_duration_measure,
 )
 
 
 def setup_routes(app, cors):
     """Setup routes and cors for app."""
     resource = cors.add(app.router.add_resource("/query"))
-    cors.add(resource.add_route("POST", query))
+    cors.add(
+        resource.add_route(
+            "POST", functools.partial(view_with_duration_measure, get_history_data)
+        )
+    )
 
     resource = cors.add(app.router.add_resource("/analyze"))
-    cors.add(resource.add_route("POST", analyze))
+    cors.add(
+        resource.add_route(
+            "POST", functools.partial(view_with_duration_measure, get_analyze_data)
+        )
+    )
 
     resource = cors.add(app.router.add_resource("/search"))
     cors.add(resource.add_route("POST", search))

--- a/metricq_grafana/utils.py
+++ b/metricq_grafana/utils.py
@@ -2,7 +2,17 @@ import math
 
 
 def sanitize_number(value):
-    """ Convert NaN and Inf to None - because JSON is dumb """
+    """Convert NaN and Inf to None - because JSON is dumb"""
     if math.isfinite(value):
         return value
     return None
+
+
+async def unpack_metric(app, metric):
+    # guess if this is a pattern (regex) to expand by sending it to the manager
+    if "(" in metric and ")" in metric:
+        metrics = await app["history_client"].get_metrics(
+            metadata=False, historic=True, selector=metric
+        )
+        return metrics
+    return [metric]

--- a/metricq_grafana/views.py
+++ b/metricq_grafana/views.py
@@ -11,6 +11,7 @@ from .amqp import (
     get_history_data,
     get_metric_list,
     get_metadata,
+    get_analyze_data,
 )
 
 logger = get_logger(__name__)
@@ -23,6 +24,29 @@ async def query(request):
         perf_begin_ns = time.perf_counter_ns()
         perf_begin_process_ns = time.process_time_ns()
         resp = await get_history_data(request.app, req_json)
+        perf_end_ns = time.perf_counter_ns()
+        perf_end_process_ns = time.process_time_ns()
+        headers = {
+            "x-request-duration": str((perf_end_ns - perf_begin_ns) / 1e9),
+            "x-request-duration-cpu": str(
+                (perf_end_process_ns - perf_begin_process_ns) / 1e9
+            ),
+        }
+    except TimeoutError:
+        # No one responds means not found
+        raise web.HTTPNotFound()
+    except ValueError:
+        raise web.HTTPBadRequest()
+    return web.json_response(resp, headers=headers)
+
+
+async def analyze(request):
+    req_json = await request.json()
+    logger.debug("Analyze request data: {}", req_json)
+    try:
+        perf_begin_ns = time.perf_counter_ns()
+        perf_begin_process_ns = time.process_time_ns()
+        resp = await get_analyze_data(request.app, req_json)
         perf_end_ns = time.perf_counter_ns()
         perf_end_process_ns = time.process_time_ns()
         headers = {


### PR DESCRIPTION
Fixes #37

This adds the `/analyze` endpoint.
Input:
```json
{
    "range": {
        "from": "2019-09-30T11:08:28.825Z",
        "to": "2019-10-01T11:08:28.825Z"
    },
    "targets": [
        {
            "metric": "foo.bar.baz"
        }
    ]
}
```

Output:
```json
[
    {
        "target": "foo.bar.baz",
        "time_measurements": {
            "http": 0.0151198
        }, 
        "minimum": 1993413.1455352155, 
        "maximum": 20325853.871336978, 
        "sum": 1164711064083.4841, 
        "count": 86400, 
        "integral_ns": 1.1647095223182117e+21, 
        "active_time_ns": 86400000000000, 
        "mean": 13480434.286090413, 
        "mean_integral": 13480434.286090413, 
        "mean_sum": 13480452.130595881
    }
]
```