### PR TITLE
Remove MetricQ (re)connection timeout

### DIFF
--- a/metricq_grafana/main.py
+++ b/metricq_grafana/main.py
@@ -5,7 +5,6 @@ import traceback
 
 import click
 
-import aio_pika
 import aiohttp_cors
 import click_completion
 import click_log
@@ -27,10 +26,15 @@ logger.handlers[0].formatter = logging.Formatter(
 click_completion.init()
 
 
-async def start_background_tasks(app):
+async def start_background_tasks(app: web.Application):
     app["history_client"] = Client(
-        app["token"], app["management_url"], client_version=version, event_loop=app.loop
+        app["token"],
+        app["management_url"],
+        client_version=version,
+        event_loop=app.loop,
+        connection_timeout=None,
     )
+
     await app["history_client"].connect()
 
 


### PR DESCRIPTION
I have no idea, how I could proberly stop the freaking thing. Not even sys.exit works. Instead, we just don't give up on reconnecting to MetricQ instead. This is fine.

Requires https://github.com/metricq/metricq-python/pull/116