### PR TITLE
fix: sma function works again for empty interval

### DIFF
--- a/metricq_grafana/functions.py
+++ b/metricq_grafana/functions.py
@@ -142,10 +142,10 @@ class MovingAverageFunction(Function):
             yield duration
 
     def transform_data(self, response):
-        if len(response) == 0:
-            return []
-
         response_aggregates = list(response.aggregates(convert=True))
+
+        if len(response_aggregates) == 0:
+            return []
 
         ma_integral_ns = 0
         ma_active_time = Timedelta(0)


### PR DESCRIPTION
The HistoryResponse for an empty interval contains 1 value, but 0 aggregates. Fixes #42 